### PR TITLE
Fix optimistic updates after seek complete

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -424,6 +424,11 @@ fn update(ui: &mut Ui, message: Message) -> Effect<Message> {
             Effect::none()
         }
 
+        Message::FromAudio(AudioMessage::SeekComplete(player_display)) => {
+            // TODO
+            Effect::none()
+        }
+
         Message::FromAudio(AudioMessage::DisplayUpdate(None)) => {
             ui.current_song = None;
             ui.progress = None;

--- a/src/app/hoverable.rs
+++ b/src/app/hoverable.rs
@@ -33,7 +33,10 @@ where
         }
     }
 
-    pub fn padding<P: Into<Padding>>(mut self, padding: P) -> Self {
+    pub fn padding<P>(mut self, padding: P) -> Self
+    where
+        P: Into<Padding>,
+    {
         self.padding = padding.into();
         self
     }

--- a/src/audio/player.rs
+++ b/src/audio/player.rs
@@ -62,6 +62,9 @@ pub enum AudioMessage {
     /// A change that affects ui state; None = player stopped
     DisplayUpdate(Option<PlayerDisplay>),
 
+    /// The first update after a seek request from the UI
+    SeekComplete(PlayerDisplay),
+
     /// The audio thread died
     AudioDied,
 }
@@ -271,6 +274,9 @@ impl Player {
             (Some(Back), None) => Ok(Effects::none()),
 
             (Some(Seek(proportion)), Some(player_state)) => {
+                // TODO
+                // in both branches, publish a specific update that
+                // 'completes' the optimistic state
                 if let Some(total) = player_state
                     .track_info
                     .progress_times(player_state.timestamp)

--- a/todo.org
+++ b/todo.org
@@ -1,5 +1,5 @@
 * Now
-- [ ] find a better way to avoid flicker
+- [X] find a better way to avoid flicker
   skipping a magic number of audio updates sucks
   need a 'seek completed' response from audio thread
     or just a flag on the normal update? separate message seems better

--- a/todo.org
+++ b/todo.org
@@ -1,9 +1,20 @@
 * Now
-- [ ] write about hoverable
-- [ ] test app on windows
+- [ ] find a better way to avoid flicker
+  skipping a magic number of audio updates sucks
+  need a 'seek completed' response from audio thread
+    or just a flag on the normal update? separate message seems better
+    does it have to care about multiple seeks in flight? like while paused
+      could have request ids or something, but hopefully that's unnecessary
+
+- [X] write about hoverable
+- [X] test app on windows
   at least make sure nothing panics - disable media controls if necessary
 
+
 * Next
+- [ ] get true gapless playback
+  start loading next file early?
+
 - [ ] add a way to search
   - modal? keyboard-based
     command pallete look
@@ -32,6 +43,7 @@
 - [ ] keep track of the queue on the ui side
   necessary for displaying the queue
 
+- [ ]
 - [ ] add media controls support on windows
   see if this could require having a window handle on the audio thread
   maybe find a workaround for that - see what Psst does
@@ -56,13 +68,6 @@
 - [ ] do the 'display_title' based on file system on import
   then allow updating it later
   this is less confusing for the user and avoids unnecessary optionals
-
-- [ ] find a better way to avoid flicker
-  skipping a magic number of audio updates sucks
-  need a 'seek completed' response from audio thread
-    or just a flag on the normal update? separate message seems better
-    does it have to care about multiple seeks in flight? like while paused
-      could have request ids or something, but hopefully that's unnecessary
 
 - [ ] load a nice startup ui quickly
   - [ ] last played song - progress and scroll?

--- a/todo.org
+++ b/todo.org
@@ -43,7 +43,6 @@
 - [ ] keep track of the queue on the ui side
   necessary for displaying the queue
 
-- [ ]
 - [ ] add media controls support on windows
   see if this could require having a window handle on the audio thread
   maybe find a workaround for that - see what Psst does


### PR DESCRIPTION
The audio thread now responds with a distinct message after a seek is complete, which allows the UI thread to avoid the janky hardcoded 'skip 2 frames' fix it had before.