### PR TITLE
Playback Refactor

### DIFF
--- a/src/audio/player.rs
+++ b/src/audio/player.rs
@@ -596,11 +596,7 @@ fn prepare_publish(
     let progress = new_state
         .track_info
         .progress_times(timestamp)
-        .map(|progress| {
-            let elapsed_duration = Duration::from_secs(progress.elapsed.seconds);
-            let media_position = MediaPosition(elapsed_duration);
-            media_position
-        });
+        .map(|progress| MediaPosition(Duration::from_secs(progress.elapsed.seconds)));
 
     let playback = if new_state.playing {
         MediaPlayback::Playing { progress }

--- a/src/audio/player.rs
+++ b/src/audio/player.rs
@@ -342,6 +342,10 @@ impl AudioEffects {
     }
 }
 
+// NOTE this is used for seeking and error states,
+// when we want to deliberately avoid publishing to media controls
+// TODO replace with explicit functions;
+// one for no_publish and one for publish_stop
 impl From<(Option<PlayerState>, Option<AudioMessage>)> for AudioEffects {
     fn from(
         (player_state, audio_message): (Option<PlayerState>, Option<AudioMessage>),
@@ -487,6 +491,8 @@ impl PlayerState {
             }
         };
 
+        // TODO what should actually happen here? we don't support the
+        // track switching that symphonia-play was trying to
         if packet.track_id() != player_state.track_info.id {
             return Ok((Some(player_state), None).into());
         }


### PR DESCRIPTION
This removes some indirection from the code for producing audio effects.

This also removes the packet id mismatch check in continue_playing. That originally came from symphonia-play, and was related to track-changing stuff (I think related to streaming?) that clef isn't supporting for now.